### PR TITLE
fixes

### DIFF
--- a/lib/aave-address-book/src/AaveMisc.sol
+++ b/lib/aave-address-book/src/AaveMisc.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0;
+
+interface IAaveEcosystemReserveController {
+  /**
+   * @notice Proxy function for ERC20's approve(), pointing to a specific collector contract
+   * @param collector The collector contract with funds (Aave ecosystem reserve)
+   * @param token The asset address
+   * @param recipient Allowance's recipient
+   * @param amount Allowance to approve
+   **/
+  function approve(
+    address collector,
+    // IERC20 token,
+    address token,
+    address recipient,
+    uint256 amount
+  ) external;
+
+  /**
+   * @notice Proxy function for ERC20's transfer(), pointing to a specific collector contract
+   * @param collector The collector contract with funds (Aave ecosystem reserve)
+   * @param token The asset address
+   * @param recipient Transfer's recipient
+   * @param amount Amount to transfer
+   **/
+  function transfer(
+    address collector,
+    // IERC20 token,
+    address token,
+    address recipient,
+    uint256 amount
+  ) external;
+
+  /**
+   * @notice Proxy function to create a stream of token on a specific collector contract
+   * @param collector The collector contract with funds (Aave ecosystem reserve)
+   * @param recipient The recipient of the stream of token
+   * @param deposit Total amount to be streamed
+   * @param tokenAddress The ERC20 token to use as streaming asset
+   * @param startTime The unix timestamp for when the stream starts
+   * @param stopTime The unix timestamp for when the stream stops
+   * @return uint256 The stream id created
+   **/
+  function createStream(
+    address collector,
+    address recipient,
+    uint256 deposit,
+    // IERC20 tokenAddress,
+    address tokenAddress,
+    uint256 startTime,
+    uint256 stopTime
+  ) external returns (uint256);
+
+  /**
+   * @notice Proxy function to withdraw from a stream of token on a specific collector contract
+   * @param collector The collector contract with funds (Aave ecosystem reserve)
+   * @param streamId The id of the stream to withdraw tokens from
+   * @param funds Amount to withdraw
+   * @return bool If the withdrawal finished properly
+   **/
+  function withdrawFromStream(
+    address collector,
+    uint256 streamId,
+    uint256 funds
+  ) external returns (bool);
+
+  /**
+   * @notice Proxy function to cancel a stream of token on a specific collector contract
+   * @param collector The collector contract with funds (Aave ecosystem reserve)
+   * @param streamId The id of the stream to cancel
+   * @return bool If the cancellation happened correctly
+   **/
+  function cancelStream(address collector, uint256 streamId)
+    external
+    returns (bool);
+}
+
+library AaveMisc {
+  address internal constant ECOSYSTEM_RESERVE =
+    0x25F2226B597E8F9514B3F68F00f494cF4f286491;
+
+  IAaveEcosystemReserveController
+    internal constant AAVE_ECOSYSTEM_RESERVE_CONTROLLER =
+    IAaveEcosystemReserveController(0x3d569673dAa0575c936c7c67c4E6AedA69CC630C);
+}

--- a/src/tests/V2CoveragePaymentPayload.t.sol
+++ b/src/tests/V2CoveragePaymentPayload.t.sol
@@ -13,8 +13,6 @@ import {IStreamable} from "../external/aave/IStreamable.sol";
 import {IERC20} from "@openzeppelin/token/ERC20/IERC20.sol";
 
 contract ProposalPaymentPayloadTest is Test {
-    address public constant AAVE_WHALE = 0xBE0eB53F46cd790Cd13851d5EFf43D12404d33E8;
-
     uint256 public proposalId;
 
     IERC20 public constant AUSDC = IERC20(0xBcca60bB61934080951369a648Fb03DF4F96263C);
@@ -44,7 +42,7 @@ contract ProposalPaymentPayloadTest is Test {
         ProposalPayload proposalPayload = new ProposalPayload();
 
         // Create Proposal
-        vm.prank(AAVE_WHALE);
+        vm.prank(GovHelpers.AAVE_WHALE);
         proposalId = DeployMainnetProposal._deployMainnetProposal(
             address(proposalPayload),
             bytes32(0x5d0543d0e66abc240eceeae5ada6240d4d6402c2ccfe5ad521824dc36be71c45) // TODO: replace with actual ipfshash

--- a/src/tests/V2CoveragePaymentPayload.t.sol
+++ b/src/tests/V2CoveragePaymentPayload.t.sol
@@ -27,9 +27,9 @@ contract ProposalPaymentPayloadTest is Test {
     IStreamable public immutable STREAMABLE_AAVE_COLLECTOR = IStreamable(AaveV2Ethereum.COLLECTOR);
     IStreamable public constant STREAMABLE_AAVE_ECOSYSTEM_RESERVE = IStreamable(AAVE_ECOSYSTEM_RESERVE);
 
-    uint256 public constant AUSDC_STREAM_AMOUNT = 175000e6 + 11840000;
+    uint256 public constant AUSDC_STREAM_AMOUNT = 175000e6;
     //TODO: whats the remainder here?
-    uint256 public constant AAVE_STREAM_AMOUNT = 1242e18 + 8640000;
+    uint256 public constant AAVE_STREAM_AMOUNT = 1242e18;
 
     // 5 months of 30 days
     uint256 public constant STREAMS_DURATION = 150 days; // 5*30 days duration
@@ -51,10 +51,10 @@ contract ProposalPaymentPayloadTest is Test {
         );
     }
 
-    // // Full Payment Term Test. Stream 5 months.
+    // Full Payment Term Test. Stream 5 months.
     function testExecuteUsdc() public {
+        uint256 actualAmountUSDC = (AUSDC_STREAM_AMOUNT / STREAMS_DURATION) * STREAMS_DURATION; // rounding
         uint256 initialChaosAUSDCBalance = AUSDC.balanceOf(CHAOS_RECIPIENT);
-        uint256 initialMainnetReserveFactorAusdcBalance = AUSDC.balanceOf(AAVE_COLLECTOR);
 
         // Capturing next Stream IDs before proposal is executed
         uint256 nextMainnetReserveFactorStreamID = STREAMABLE_AAVE_COLLECTOR.getNextStreamId();
@@ -77,10 +77,10 @@ contract ProposalPaymentPayloadTest is Test {
 
         assertEq(senderAusdc, AAVE_COLLECTOR);
         assertEq(recipientAusdc, CHAOS_RECIPIENT);
-        assertEq(depositAusdc, AUSDC_STREAM_AMOUNT);
+        assertEq(depositAusdc, actualAmountUSDC);
         assertEq(tokenAddressAusdc, address(AUSDC));
         assertEq(stopTimeAusdc - startTimeAusdc, STREAMS_DURATION);
-        assertEq(remainingBalanceAusdc, AUSDC_STREAM_AMOUNT);
+        assertEq(remainingBalanceAusdc, actualAmountUSDC);
 
         // Checking if Chaos can withdraw from streams
         vm.startPrank(CHAOS_RECIPIENT);
@@ -113,12 +113,13 @@ contract ProposalPaymentPayloadTest is Test {
         }
 
         //check final numbers:
-        assertEq(AUSDC.balanceOf(CHAOS_RECIPIENT) >= initialChaosAUSDCBalance + AUSDC_STREAM_AMOUNT, true);
+        assertEq(AUSDC.balanceOf(CHAOS_RECIPIENT) >= initialChaosAUSDCBalance + actualAmountUSDC, true);
         vm.stopPrank();
     }
 
     // Full Payment Term Test. Stream 5 months.
     function testExecuteAave() public {
+        uint256 actualAmountAave = (AAVE_STREAM_AMOUNT / STREAMS_DURATION) * STREAMS_DURATION; // rounding
         uint256 initialChaosAAVEBalance = AAVE.balanceOf(CHAOS_RECIPIENT);
         uint256 initialEcosystemReserveAaveBalance = AAVE.balanceOf(AAVE_ECOSYSTEM_RESERVE);
 
@@ -142,10 +143,10 @@ contract ProposalPaymentPayloadTest is Test {
 
         assertEq(senderAave, AAVE_ECOSYSTEM_RESERVE);
         assertEq(recipientAave, CHAOS_RECIPIENT);
-        assertEq(depositAave, AAVE_STREAM_AMOUNT);
+        assertEq(depositAave, actualAmountAave);
         assertEq(tokenAddressAave, address(AAVE));
         assertEq(stopTimeAave - startTimeAave, STREAMS_DURATION);
-        assertEq(remainingBalanceAave, AAVE_STREAM_AMOUNT);
+        assertEq(remainingBalanceAave, actualAmountAave);
 
         // Checking if Chaos can withdraw from streams
         vm.startPrank(CHAOS_RECIPIENT);
@@ -169,7 +170,7 @@ contract ProposalPaymentPayloadTest is Test {
         }
 
         //check final numbers:
-        assertEq(AAVE.balanceOf(CHAOS_RECIPIENT) >= initialChaosAAVEBalance + AAVE_STREAM_AMOUNT, true);
+        assertEq(AAVE.balanceOf(CHAOS_RECIPIENT) >= initialChaosAAVEBalance + actualAmountAave, true);
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
Following feedback from BGD:
1. Aave Ecosystem Reserve imported from the address book
2. The million comments for USDC removed
3. stream amount calculated more elegantly 
4. Interface of IAaveEcosystemReserveController imported from AaveMisc
5. on tests - used Whale from the address book



I couldn't change the test to use AaveMisc.AAVE_ECOSYSTEM_RESERVE_CONTROLLER because of the following error:

error[8349]: TypeError: Initial value for constant variable has to be compile-time constant.
  --> src/tests/V2CoveragePaymentPayload.t.sol:25:54:
   |
25 |     address public constant AAVE_ECOSYSTEM_RESERVE = AaveMisc.AAVE_ECOSYSTEM_RESERVE_CONTROLLER;
   |